### PR TITLE
steps for connecting two machine on same subnet with l4s configure on both of them

### DIFF
--- a/L4SkernelPatchSetUp.md
+++ b/L4SkernelPatchSetUp.md
@@ -261,8 +261,8 @@ iperf3 -c [server_ip] -p 5201 -t 20 -Z
   ```bash
   ss -tin | grep ecn  # Should show "ecn" in output
   ```
-  
-## **Step 8: Compile the Kernel from Source (Optional)**
+
+## **Step 9: Compile the Kernel from Source (Optional)**
 If you prefer to compile the kernel instead of using the pre-built package:
 
 1. **Clone the L4S Kernel Repository**


### PR DESCRIPTION

###  Enhancements Added  
1. **Two-Machine Test Framework**  
   - Added detailed steps for cross-validating L4S between machines on the same subnet  
   - Included expected `iperf3` outputs for both traditional TCP and L4S modes  

2. **Troubleshooting Matrix**  
   ```markdown
   | Symptom                | Verification Step | Solution                     |
   |------------------------|-------------------|------------------------------|
   | ECN not negotiating    | Step 8.3          | `sudo sysctl -w net.ipv4.tcp_ecn=3` |
   | DualPI2 qdisc missing  | Step 8.4          | Reapply `tc qdisc` command   |
   ```

3. **Validation Automation**  
   - Created persistent configuration scripts (`/etc/network/if-up.d/`)  
   - Added kernel module auto-load instructions via `modprobe`  

4. **Performance Benchmarking**  
   - Standardized test commands with `-Z` (Prague) vs `-C cubic` comparisons  
   - Added latency measurement flags (`-i`, `-t`) for precise analysis  

5. **Documentation Improvements**  
   - Added ✅ visual indicators for all verification steps  
   - Clarified port usage (5201 as default for `iperf3`)  
